### PR TITLE
의역 제안 및 오타 수정

### DIFF
--- a/language-guide-1/extensions.md
+++ b/language-guide-1/extensions.md
@@ -15,7 +15,7 @@ Extensions in Swift can:
 In Swift, you can even extend a protocol to provide implementations of its requirements or add additional functionality that conforming types can take advantage of. For more details, see Protocol Extensions.
 -->
 
-_확장 \(Extensions\)_ 은 기존의 클래스, 구조체, 열거형, 또는 프로토콜 타입에 새로운 기능을 추가합니다. 이것은 기존 소스 코드에 접근 권한이 없는 타입을 확장하는 기능이 포함됩니다 \(_소급 모델링 \(retroactive modeling\)_ 이라고 함\). 확장은 Objective-C에서 카테고리와 유사합니다 \(Objective-C 카테고리와 달리 Swift 확장은 이름이 없습니다\).
+_확장 \(Extensions\)_ 은 기존의 클래스, 구조체, 열거형, 또는 프로토콜 타입에 새로운 기능을 추가합니다. 이것은 기존 소스 코드에 접근 권한이 없는 타입을 확장하는 기능이 포함됩니다 \(_소급 모델링 \(retroactive modeling\)_ 이라고 함\). 확장은 Objective-C의 카테고리와 유사합니다 \(Objective-C 카테고리와 달리 Swift 확장은 이름이 없습니다\).
 
 Swift에서 확장은 다음을 수행할 수 있습니다:
 
@@ -54,7 +54,7 @@ extension SomeType {
 An extension can extend an existing type to make it adopt one or more protocols. To add protocol conformance, you write the protocol names the same way as you write them for a class or structure:
 -->
 
-확장은 하나 이상의 프로토콜을 채택하여 기존 타입을 확장할 수 있습니다. 프로토콜 준수를 추가하려면 클래스 또는 구조체에 대해 작성하는 것과 동일하게 프로토콜 이름을 작성합니다:
+확장은 하나 이상의 프로토콜을 채택하여 기존 타입을 확장할 수 있습니다. 프로토콜 준수를 추가할 때 클래스 또는 구조체를 작성하는 것과 동일한 방법으로 프로토콜 이름을 작성합니다:
 
 ```swift
 extension SomeType: SomeProtocol, AnotherProtocol {
@@ -78,7 +78,7 @@ If you define an extension to add new functionality to an existing type, the new
 -->
 
 > NOTE   
-> 기존 타입에 새로운 기능을 추가하기 위해 확장을 정의한다면 새로운 기능은 확장이 정의되기 전에 생성되었어도 모든 기존에 인스턴스에서 사용 가능합니다.
+> 기존 타입에 새로운 기능을 추가하기 위해 확장을 정의한다면 새로운 기능은 확장이 정의되기 전에 생성 된 기존 인스턴스에서도 사용 가능합니다.
 
 ## 계산된 프로퍼티 \(Computed Properties\)
 
@@ -114,7 +114,7 @@ Other units require some conversion to be expressed as a value measured in meter
 These properties are read-only computed properties, and so they’re expressed without the get keyword, for brevity. Their return value is of type Double, and can be used within mathematical calculations wherever a Double is accepted:
 -->
 
-이 계산된 프로퍼티는 특정 길이의 단위로 `Double` 값을 표현합니다. 계산된 프로퍼티로 이러한 프로퍼티의 이름은 거리 변환을 수행하기 위해 해당 리터럴 값을 사용하는 방법으로 부동 소수점 값에 점 구문을 사용할 수 있습니다.
+이 계산된 프로퍼티는 특정 길이의 단위로 `Double` 값을 표현합니다. 계산된 프로퍼티로 구현 되었지만 이러한 프로퍼티의 이름은 거리 변환을 수행하기 위해 해당 리터럴 값을 사용하는 방법으로 부동 소수점 값에 점 구문을 사용할 수 있습니다.
 
 이 예제에서 `1.0` 의 `Double` 값은 "1 미터" 로 표시됩니다. `1.m` 표현식은 `Double` 값의 `1.0` 을 계산한 것으로 간주되므로 `m` 계산된 프로퍼티가 `self` 를 반환하는 이유입니다.
 


### PR DESCRIPTION
말씀 해주신 부분 다시 고민하여 수정 하였습니다! 이전 PR은 merge 해주셔서 새로 PR 드립니다!

일전에 "계산된 프로퍼티로 이러한 프로퍼티의"로 수정하였던 이유가 영문에서 지칭한 they가 이전 문장과 같은 것을 지칭하기에 "구현되지만"을 생략하였습니다. 근데 한번 더 짚어주셔서 문장에 대해 더 고민하다보니 기존의 "구현되지만"을 "되었지만"으로 수정하여 이전 문장을 재지칭 해주는 게 어떨까라는 생각이 들어 수정하였습니다.

해당 부분 수정하면서 다른 부분들도 다시 검토하게 되었고 추가적으로 제안 드리면 좋을 거 같은 부분들 함께 수정하여 PR 드립니다.
1. Objective-C의 카테고리를 언급하기에 "에서" 보다 "의"가 더 알맞다고 생각하였습니다.
2. 영문에서 동일한 방법으로 작성한다고 언급하기에 작성 시에라는 문맥에 맞게 영문을 토대로 수정해보았습니다.
3. 확장이 생성되기 이전의 인스터스에서도 사용가능하다는 의미를 전달하는 게 영문과 맥락이 같다 생각하여 의역해보았습니다.
4. 짚어주신 부분 앞서 언급한대로 다시 고민해서 수정 해보았습니다.

항상 이렇게 의견 나눠 주시고 반겨주셔서 감사드립니다! 