### PR TITLE
콜렉션 타입 (collection-types) 예제 설명 수정

### DIFF
--- a/language-guide-1/collection-types.md
+++ b/language-guide-1/collection-types.md
@@ -160,7 +160,7 @@ shoppingList[0] = "Six eggs"
 
 서브 스크립트 구문을 사용할 때 인덱스는 유효해야 합니다. 예를 들어 `shoppingList[shoppingList.count] = "Salt"` 으로 배열 끝에 추가하려고 하면 런타임 에러가 발생합니다.
 
-변경할 값들이 변경할 범위와 다른 길이를 가지고 있더라도 서브 스크립트 구문으로 범위 안에 값을 한번에 변경할 수 있습니다. 아래 예제는 `"Chocolate Spread"`, `"Cheese"` 를 `"Bananas"` 와 `"Apples"` 로 대체합니다:
+변경할 값들이 변경할 범위와 다른 길이를 가지고 있더라도 서브 스크립트 구문으로 범위 안에 값을 한번에 변경할 수 있습니다. 아래 예제는 `"Chocolate Spread"`, `"Cheese"`, `"Butter"` 를 `"Bananas"` 와 `"Apples"` 로 대체합니다:
 
 ```swift
 shoppingList[4...6] = ["Bananas", "Apples"]


### PR DESCRIPTION
문서의 흐름상 대치되는 대상이 번역본의 대상과 상이하여 원문 비교하여 수정 요청드립니다.
배열의 요소를 나열하는 것이므로 가독성을 해치지 않도록 'and'를 번역하지 않았습니다.

|      | 원문                                                                                          | 번역 ("Butter" 누락)                                                                                             |
|------|----------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
| 내용 | The following example replaces "Chocolate Spread", "Cheese", **_and "Butter"_** with "Bananas" and "Apples": | 아래 예제는 "Chocolate Spread", "Cheese" 를 "Bananas" 와 "Apples" 로 대체합니다: |

- 원문 링크: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/collectiontypes

생태계에 기여해주셔서 감사합니다.